### PR TITLE
Cleanup

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -123,6 +123,7 @@ WARNFLAGS ?= -Wall
 CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility=hidden -I../../src
 LDFLAGS += $(SHARED)
 
+# test for raspberry pi 1
 ifeq ("$(MACHINE)","armv6l")
   VC=1
 endif
@@ -131,6 +132,23 @@ ifeq ($(VC), 1)
   CFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM
   LDLIBS += -lm -L/opt/vc/lib -lbcm_host -lvcos -lvchiq_arm -lopenmaxil
 endif
+
+# test for presence of SDL
+ifeq ($(origin SDL_CFLAGS) $(origin SDL_LDLIBS), undefined undefined)
+  SDL_CONFIG = $(CROSS_COMPILE)sdl2-config
+  ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
+    SDL_CONFIG = $(CROSS_COMPILE)sdl-config
+    ifeq ($(shell which $(SDL_CONFIG) 2>/dev/null),)
+      $(error No SDL development libraries found!)
+    else
+      $(warning Using SDL 1.2 libraries)
+    endif
+  endif
+  SDL_CFLAGS  += $(shell $(SDL_CONFIG) --cflags)
+  SDL_LDLIBS += $(shell $(SDL_CONFIG) --libs)
+endif
+CFLAGS += $(SDL_CFLAGS)
+LDLIBS += $(SDL_LDLIBS)
 
 # Since we are building a shared library, we must compile with -fPIC on some architectures
 # On 32-bit x86 systems we do not want to use -fPIC because we don't have to and it has a big performance penalty on this arch

--- a/src/main.c
+++ b/src/main.c
@@ -67,7 +67,7 @@
 #define OUTPUT_PORT 1
 
 /* Latency in ms that the audio buffers may have*/
-#define DEFAULT_LATENCY 300
+#define DEFAULT_LATENCY 100
 
 /* Number of buffers used by Audio*/
 #define DEFAULT_NUM_BUFFERS 3
@@ -125,7 +125,7 @@ static uint32_t uiNumBuffers = DEFAULT_NUM_BUFFERS;
 
 static uint32_t	bNative = 0;
 
-static uint32_t uiUnderrunMode = 1;
+static uint32_t uiUnderrunMode = 0;
 
 static uint32_t critical_failure = 0;
 

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,7 @@
 #include "main.h"
 #include "osal_dynamiclib.h"
 
-extern uint32_t SDL_GetTicks(void);
+#include <SDL.h>
 
 #define DEFAULT_BUFFER_SIZE 2048
 
@@ -229,9 +229,9 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Con
 	ConfigSetParameter = 	(ptr_ConfigSetParameter) 	osal_dynlib_getproc(CoreLibHandle, "ConfigSetParameter");
 	ConfigGetParameter = 	(ptr_ConfigGetParameter) 	osal_dynlib_getproc(CoreLibHandle, "ConfigGetParameter");
 	ConfigSetDefaultInt = 	(ptr_ConfigSetDefaultInt) 	osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultInt");
-	ConfigSetDefaultFloat = (ptr_ConfigSetDefaultFloat) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultFloat");
+	ConfigSetDefaultFloat = (ptr_ConfigSetDefaultFloat) 	osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultFloat");
 	ConfigSetDefaultBool = 	(ptr_ConfigSetDefaultBool) 	osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultBool");
-	ConfigSetDefaultString = (ptr_ConfigSetDefaultString) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultString");
+	ConfigSetDefaultString = (ptr_ConfigSetDefaultString) 	osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultString");
 	ConfigGetParamInt = 	(ptr_ConfigGetParamInt) 	osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamInt");
 	ConfigGetParamFloat = 	(ptr_ConfigGetParamFloat) 	osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamFloat");
 	ConfigGetParamBool = 	(ptr_ConfigGetParamBool) 	osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamBool");
@@ -472,19 +472,19 @@ static int32_t audioplay_create(uint32_t num_buffers,
 	error = OMX_SendCommand(OMX_Handle, OMX_CommandPortDisable, PORT_INDEX, NULL);
 
 	int nPorts;
-    int startPortNumber;
-    int n;
+    	int startPortNumber;
+    	int n;
 	OMX_PORT_PARAM_TYPE param2;
 
 	memset(&param2, 0, sizeof(OMX_PORT_PARAM_TYPE));
 	param2.nSize = sizeof(OMX_PORT_PARAM_TYPE);
 	param2.nVersion.nVersion = OMX_VERSION;
 
-    error = OMX_GetParameter(OMX_Handle, OMX_IndexParamOtherInit, &param2);
-    if(error != OMX_ErrorNone)
-{
+    	error = OMX_GetParameter(OMX_Handle, OMX_IndexParamOtherInit, &param2);
+    	if(error != OMX_ErrorNone)
+	{
 		DebugMessage(M64MSG_ERROR, "line %d: Failed to Get OMX Parameters. Error 0x%X",__LINE__, error);
-    }
+    	}
 	else
 	{
 		startPortNumber = ((OMX_PORT_PARAM_TYPE)param2).nStartPortNumber;
@@ -659,7 +659,7 @@ static uint32_t SendBufferToAudio()
 	DEBUG_PRINT("audioplay_play_buffer()\n");
 	
 	audioBuffers[uiBufferIndex]->nOffset = 0;
-    audioBuffers[uiBufferIndex]->nFilledLen = (uiSecondaryBufferSamples * 4);
+    	audioBuffers[uiBufferIndex]->nFilledLen = (uiSecondaryBufferSamples * 4);
 
 	error = OMX_EmptyThisBuffer(OMX_Handle, audioBuffers[uiBufferIndex++]);
 	if ( error != OMX_ErrorNone)
@@ -846,7 +846,7 @@ EXPORT int CALL InitiateAudio( AUDIO_INFO Audio_Info )
 	error = OMX_Init();
 	if(error != OMX_ErrorNone) DebugMessage(M64MSG_ERROR, "%d OMX_Init() failed", __LINE__);
 
-return 1;
+	return 1;
 }
 
 static void InitializeAudio(int freq)
@@ -1077,5 +1077,3 @@ EXPORT const char * CALL VolumeGetString(void)
 {
 	return "100%";
 }
-
-

--- a/src/main.h
+++ b/src/main.h
@@ -19,6 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+#include "m64p_config.h"
+
 /* version info */
 #define SDL_AUDIO_PLUGIN_VERSION 0x020000
 #define AUDIO_PLUGIN_API_VERSION 0x020000


### PR DESCRIPTION
-use better defaults
-cleanup main.c and main.h (indentions and so on)
-use SDL2 if possible
-use inlude SDL.h instead of extern SDL_GetTicks
-main.h add missing header file
